### PR TITLE
downgrade min quarto requirement

### DIFF
--- a/_extensions/dime/_extension.yml
+++ b/_extensions/dime/_extension.yml
@@ -1,7 +1,7 @@
 title: DIME Presentation Template
 author: Bernhard Bieri
 version: 0.0.1
-quarto-required: ">=1.3.450"
+quarto-required: ">=1.3.361"
 contributes:
   formats:
     revealjs:

--- a/_extensions/worldbank/_extension.yml
+++ b/_extensions/worldbank/_extension.yml
@@ -1,7 +1,7 @@
 title: World Bank Presentation Template
 author: Bernhard Bieri
 version: 0.0.1
-quarto-required: ">=1.3.450"
+quarto-required: ">=1.3.361"
 contributes:
   formats: 
     revealjs:


### PR DESCRIPTION
On my WB computer, I was not able to update to this version of Quarto. 

My guess is that this is due to the highest version of RStudio I can install on my WB computer without asking ITS for help is not a recent enough version to install the latest stable version of quarto. 

The `_extension.yml` files in the DIME and the WB themes require the latest stable version of quarto. I downgraded to the version of quarto that I was able to update to. This seem to work for me. 

@BBieri , do you see any reason why this is not a good idea? Eventually we need to update this, but we can do that when ITS has updated the version of RStudio that a user can self install. 